### PR TITLE
Fix escaping of XML

### DIFF
--- a/dicttoxml.py
+++ b/dicttoxml.py
@@ -17,17 +17,17 @@ def debug_notify(*args):
 
 def xml_escape(s):
     if type(s) == str:
+        s = s.replace('&',  '&amp;')
         s = s.replace('"',  '&quot;')
         s = s.replace('\'', '&apos;')
         s = s.replace('<',  '&lt;')
         s = s.replace('>',  '&gt;')
-        s = s.replace('&',  '&amp;')
     elif type(s) == unicode:
+        s = s.replace(u'&',  u'&amp;')
         s = s.replace(u'"',  u'&quot;')
         s = s.replace(u'\'', u'&apos;')
         s = s.replace(u'<',  u'&lt;')
         s = s.replace(u'>',  u'&gt;')
-        s = s.replace(u'&',  u'&amp;')
     return s
 
 def convert(obj):


### PR DESCRIPTION
Right now `xml_escape returns a double escape string, eg:

```
xml_escape("Dracula's") == "Dracula&amp;apos;"
```

Instead, this test should pass:

```
assertEquals("Dracula&apos;s", xml_espcape("Dracula's")
```
