### PR TITLE
Substitute spaces for underscore in dictionary keys with spaces

### DIFF
--- a/dicttoxml.py
+++ b/dicttoxml.py
@@ -101,14 +101,14 @@ def convert_dict(obj, ids, parent):
             addline(convert_bool(k, v, attr))
         elif isinstance(v, dict):
             addline('<%s type="dict"%s>%s</%s>' % (
-                k, make_attrstring(attr), convert_dict(v, ids, k), k)
+                k.replace(" ", "_"), make_attrstring(attr), convert_dict(v, ids, k), k.replace(" ", "_"))
             )
         elif type(v) in (list, set, tuple) or isinstance(v, collections.Iterable):
             addline('<%s type="list"%s>%s</%s>' % (
-                k, make_attrstring(attr), convert_list(v, ids, k), k)
+                k.replace(" ", "_"), make_attrstring(attr), convert_list(v, ids, k), k.replace(" ", "_"))
             )
         elif v is None:
-            addline('<%s type="null"%s></%s>' % (k, make_attrstring(attr), k))
+            addline('<%s type="null"%s></%s>' % (k.replace(" ", "_"), make_attrstring(attr), k.replace(" ", "_")))
         else:
             raise TypeError('Unsupported data type: %s (%s)' % (obj, type(obj).__name__))
     return ''.join(output)
@@ -151,7 +151,7 @@ def convert_bool(k, v, attr={}):
     """Converts a boolean into an XML element"""
     logging.info('Inside convert_bool(): k=%s, type(v) is: %s' % (k, type(v).__name__))
     attrstring = make_attrstring(attr)
-    return '<%s type="bool"%s>%s</%s>' % (k, attrstring, unicode(v).lower(), k)
+    return '<%s type="bool"%s>%s</%s>' % (k.replace(" ", "_"), attrstring, unicode(v).lower(), k.replace(" ", "_"))
 
 def dicttoxml(obj, root=True, ids=False):
     """Converts a python object into XML"""
@@ -164,3 +164,4 @@ def dicttoxml(obj, root=True, ids=False):
     else:
         addline(convert(obj, ids, parent=''))
     return ''.join(output)
+    


### PR DESCRIPTION
I have been using your library a bit today and was trying to convert dictionaries with spaces in the keys. This didn't work so well :-) I made a change to your code to replace any spaces in keys with underscores. Maybe you'd like to include this?
