### PR TITLE
Include the license and readme in PyPI tarballs

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include README.markdown LICENSE.txt


### PR DESCRIPTION
I've posed dicttoxml for inclusion in Fedora and EPEL (https://bugzilla.redhat.com/show_bug.cgi?id=1084199), and they'd like the licence included in the tarball so that there's more of a guarantee that the LICENSE file for a given release agrees with the actual license for that release.

This includes the README too, for completeness' sake.

Obsoletes #15.
