### PR TITLE
 data type for each element to be made optional in the resulting xml

### DIFF
--- a/dicttoxml.py
+++ b/dicttoxml.py
@@ -236,8 +236,3 @@ def dicttoxml(obj, root=True, ids=False,attr_type=True):
         else:
             addline(convert(obj, ids, parent='',attr_type=True))
     return ''.join(output)
-
-
-
-
-


### PR DESCRIPTION
As per the current code, each element in the final xml that is generated contains a "type" attribute with the datatype. this pull request is to review the code change that makes it optional. 

The code contains a new attribute "attr_type" which is set to True by default, so it will work as the current code does. If it is set to False, then the resulting xml will not contain the type attribute for the elements.
