### PR TITLE
force convert to utf-8

### DIFF
--- a/dicttoxml.py
+++ b/dicttoxml.py
@@ -218,5 +218,5 @@ def dicttoxml(obj, root=True, custom_root='root', ids=False, attr_type=True):
         addline('<%s>%s</%s>' % (custom_root, convert(obj, ids, attr_type, parent=custom_root), custom_root))
     else:
         addline(convert(obj, ids, attr_type, parent=''))
-    return ''.join(output)
+    return ''.join(output).encode('utf-8')
 


### PR DESCRIPTION
When I come to handle a xml with Chinese characters in it, I came to this lib. But soon the xml.etree.ElementTree prompt me that there's an error while parsing. Soon I discovered that the Chinese character is encoding with Unicode while the header of xml tells 'UTF-8'. So I changed the last line of dicttoxml.py with `.encode('utf-8')` added and which avoids the interpreting problem of Chinese character.
