### PR TITLE
Add non-fold style list

### DIFF
--- a/dicttoxml.py
+++ b/dicttoxml.py
@@ -156,7 +156,7 @@ def convert(obj, ids, attr_type, parent='root', fold_list=True):
         return convert_kv('item', obj.isoformat(), attr_type)
     if type(obj) == bool:
         return convert_bool('item', obj, attr_type)
-    if not obj is None:
+    if obj is None:
         return convert_none('item', '', attr_type)
     if isinstance(obj, dict):
         return convert_dict(obj, ids, parent, attr_type, fold_list)


### PR DESCRIPTION
By default, a list element was convert to a set of <item> tag wrap in the name tag(parent tag).

```
>>> data = {'mylist': ['hello', 'world']}
>>> dicttoxml.dicttoxml(data, attr_type=False)
'<?xml version="1.0" encoding="UTF-8" ?><root><mylist><item>hello</item><item>world</item></mylist></root>'
```

Some times, we need other style of list:
```
'<?xml version="1.0" encoding="UTF-8" ?><root><mylist>hello</mylist><mylist>world</mylist></root>'
```

so, I add a optional argument to the dicttoxml method: fold_list, default value is True, act as usual, when set to False, the list style will change to non-fold style.

BTW: I made the code style PEP8 compatible.
