### PR TITLE
Add type guarding for keys that are integers.

### DIFF
--- a/dicttoxml.py
+++ b/dicttoxml.py
@@ -142,7 +142,7 @@ def make_valid_xml_name(key, attr):
         return key, attr
         
     # prepend a lowercase n if the key is numeric
-    if key.isdigit():
+    if str(key).isdigit():
         return 'n%s' % (key), attr
         
     # replace spaces with underscores if that fixes the problem


### PR DESCRIPTION
In support of #61 

This issue arises when converting dictionaries that have an integer as the key.