### PR TITLE
First edition of custom attributes. Work in Progress

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -240,6 +240,41 @@ Starting in version 1.7.1, you can wrap values in CDATA by setting the optional 
 
 If you do not set `cdata` to `True`, the default value is `False` and values are not wrapped.
 
+Adding Custom Attributes
+========================
+
+You can add custom attributes to nodes by adding a child `dict` named `@attrs` to a parent `dict` like so:
+
+```python3
+my_dict = {
+    "Family": {
+        "@attrs": {
+            "Tree": "Menelaws"
+        },
+        "Name": "Lewis Menelaws",
+        "Occupation": "Programmer",
+        "Programming Language": "Python"
+    }
+}
+```
+The key will be the name of the custom attribute while the value will be the value of that custom attribute.
+
+Running a standard `dicttoxml` you will get a result like this:
+
+```xml
+<?xml version="1.0" encoding="UTF-8" ?>
+<FamilyTree>
+    <Family Tree="Menelaws">
+        <Name>Lewis Menelaws</Name>
+        <Occupation>Programmer</Occupation>
+        <Programming_Language>Python</Programming_Language>
+    </Family>
+</FamilyTree>
+```
+
+
+
+
 Debugging
 =========
 

--- a/dicttoxml.py
+++ b/dicttoxml.py
@@ -226,8 +226,7 @@ def convert_dict(obj, ids, parent, attr_type, item_func, cdata):
     
             if list(val.keys())[0] == '@attrs':
                 # If first item is @attrs
-
-                print('hi there')
+                
                 custom_attrs = val['@attrs']
                 val.pop('@attrs', None)
                 addline('<%s%s>%s</%s>' % (

--- a/dicttoxml.py
+++ b/dicttoxml.py
@@ -208,9 +208,7 @@ def convert_dict(obj, ids, parent, attr_type, item_func, cdata):
         LOG.info('Looping inside convert_dict(): key="%s", val="%s", type(val)="%s"' % (
             unicode_me(key), unicode_me(val), type(val).__name__)
         )
-
         attr = {} if not ids else {'id': '%s' % (get_unique_id(parent)) }
-
         key, attr = make_valid_xml_name(key, attr)
 
         if isinstance(val, numbers.Number) or type(val) in (str, unicode):
@@ -225,12 +223,26 @@ def convert_dict(obj, ids, parent, attr_type, item_func, cdata):
         elif isinstance(val, dict):
             if attr_type:
                 attr['type'] = get_xml_type(val)
-            addline('<%s%s>%s</%s>' % (
-                key, make_attrstring(attr), 
-                convert_dict(val, ids, key, attr_type, item_func, cdata), 
-                key
+    
+            if list(val.keys())[0] == '@attrs':
+                # If first item is @attrs
+
+                print('hi there')
+                custom_attrs = val['@attrs']
+                val.pop('@attrs', None)
+                addline('<%s%s>%s</%s>' % (
+                    key, make_attrstring(custom_attrs),
+                    convert_dict(val, ids, key, attr_type, item_func, cdata),
+                    key
+                    )
                 )
-            )
+            else:        
+                addline('<%s%s>%s</%s>' % (
+                    key, make_attrstring(attr), 
+                    convert_dict(val, ids, key, attr_type, item_func, cdata), 
+                    key
+                    )
+                )
 
         elif isinstance(val, collections.Iterable):
             if attr_type:


### PR DESCRIPTION
I needed something that would allow me to create custom attributes. This was discussed in #27. I added a hack that will allow you to create custom attributes in similar fashion to how @mstrcnvs mentioned in his solution.

Here is how it works:

```python3
my_dict = {
    "Family": {
        "@attrs": {
            "Tree": "Menelaws"
        },
        "Name": "Lewis Menelaws",
        "Occupation": "Programmer",
        "Programming Language": "Python"
    }
}
```
I create a dictionary as usual. I want my "Family" node to have a custom attribute of "Tree" with the value being "Menelaws". I do this by creating a key at the first position called "@attrs" and having a key/value of what I want there to be.

Currently, I am unsure if multiple key value will work. This is still a work in development. After you do a standard `dicttoxml`:

```python3
xml = dicttoxml.dicttoxml(
    my_dict,
    custom_root='FamilyTree',
    attr_type=False
)
```

You will get this as the output:

```xml
<?xml version="1.0" encoding="UTF-8" ?>
<FamilyTree>
    <Family Tree="Menelaws">
        <Name>Lewis Menelaws</Name>
        <Occupation>Programmer</Occupation>
        <Programming_Language>Python</Programming_Language>
    </Family>
</FamilyTree>
```

I would love to see some feedbacks/code review and some input on how I can make this better or what features to add. 

Thanks for the awesome package. It's helped me a lot.