### PR TITLE
Convert XML string back to Python object given type attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,138 @@
+# Visual Studio Code files
+.vscode
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+*.code-workspace
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/

--- a/README.markdown
+++ b/README.markdown
@@ -56,6 +56,8 @@ Supports item (`int`, `float`, `bool`, `str`, `none`) and collection (`list`, an
 
 Data types are parsed from the type attributes of each element in the XML string. Therefore, type attributes must be enabled (attr_type=True) when creating the XML from DictToXML.
 
+Tip: Since DicttoXML converts the empty string ("") to "none", XMLtoDict will convert "none" to an empty string "". Bear this im mind when using this function to parse an XML.
+
 **This module should work in Python 2.6+ and Python 3.**
 
 Installation

--- a/README.markdown
+++ b/README.markdown
@@ -6,6 +6,9 @@ Converts a Python dictionary or other native data type into a valid XML string.
 Details
 =======
 
+DicttoXML
+---------
+
 Supports item (`int`, `float`, `long`, `decimal.Decimal`, `bool`, `str`, `unicode`, `datetime`, `none` and other number-like objects) and collection (`list`, `set`, `tuple` and `dict`, as well as iterable and dict-like objects) data types, with arbitrary nesting for the collections. Items with a `datetime` type are converted to ISO format strings. Items with a `None` type become empty XML elements.
 
 The root object passed into the `dicttoxml` method can be any of the supported data types.
@@ -36,6 +39,13 @@ Note: `datetime` data types are converted into ISO format strings, and `unicode`
 Elements with an unsupported data type raise a TypeError exception. 
 
 If an element name is invalid XML, it is rendered with the name "key" and the invalid name is included as a `name` attribute. E.g. `{ "^.{0,256}$": "foo" }` would be rendered `<key name="^.{0,256}$">foo</key>`. An exception is element names with spaces, which are converted to underscores.
+
+XMLtoDict
+---------
+
+Supports item (`int`, `float`, `bool`, `str`, `none`) and collection (`list`, and `dict`) data types, with arbitrary nesting for the collections.
+
+Data types are parsed from the type attributes of each element in the XML string. Therefore, type attributes must be enabled (attr_type=True) when creating the XML from DictToXML.
 
 **This module should work in Python 2.6+ and Python 3.**
 

--- a/README.markdown
+++ b/README.markdown
@@ -45,6 +45,15 @@ XMLtoDict
 
 Supports item (`int`, `float`, `bool`, `str`, `none`) and collection (`list`, and `dict`) data types, with arbitrary nesting for the collections.
 
+    XML    -> Python
+    int       int
+    float     float
+    str       str
+    null      None
+    bool      bool
+    list      list
+    dict      dict
+
 Data types are parsed from the type attributes of each element in the XML string. Therefore, type attributes must be enabled (attr_type=True) when creating the XML from DictToXML.
 
 **This module should work in Python 2.6+ and Python 3.**

--- a/dicttoxml.py
+++ b/dicttoxml.py
@@ -399,7 +399,8 @@ def dicttoxml(obj, root=True, custom_root='root', ids=False, attr_type=True,
         addline(convert(obj, ids, attr_type, item_func, cdata, parent=''))
     return ''.join(output).encode('utf-8')
 
-def cast_from_attribute(attr, text):
+def cast_from_attribute(text, attr):
+    """Converts XML text into a Python data format based on the tag attribute"""
     if attr == "str":
         if str(text).lower() != "none":
             return text
@@ -426,6 +427,7 @@ def cast_from_attribute(attr, text):
         raise TypeError("unsupported type: only 'str', 'int', 'float', 'bool', 'list', 'dict', and 'None' supported")
 
 def xmltodict(obj):
+    """Converts an XML string into a Python object based on eac tag's attribute"""
     def add_to_output(obj, child):
         if isinstance(obj, dict):
             obj.update({child.tag: cast_from_attribute(child.attrib["type"], child.text)})

--- a/dicttoxml.py
+++ b/dicttoxml.py
@@ -430,11 +430,11 @@ def xmltodict(obj):
     """Converts an XML string into a Python object based on eac tag's attribute"""
     def add_to_output(obj, child):
         if isinstance(obj, dict):
-            obj.update({child.tag: cast_from_attribute(child.attrib["type"], child.text)})
+            obj.update({child.tag: cast_from_attribute(child.text, child.attrib["type"])})
             for sub in child:
                 add_to_output(obj[child.tag], sub)
         elif isinstance(obj, list):
-            obj.append(cast_from_attribute(child.attrib["type"], child.text))
+            obj.append(cast_from_attribute(child.text, child.attrib["type"]))
             for sub in child:
                 add_to_output(obj[-1], sub)
     root = ElementTree.fromstring(obj)

--- a/dicttoxml.py
+++ b/dicttoxml.py
@@ -429,6 +429,8 @@ def cast_from_attribute(text, attr):
 def xmltodict(obj):
     """Converts an XML string into a Python object based on eac tag's attribute"""
     def add_to_output(obj, child):
+        if "type" not in child.attrib:
+            raise ValueError("XML must contain type attributes for each tag")
         if isinstance(obj, dict):
             obj.update({child.tag: cast_from_attribute(child.text, child.attrib["type"])})
             for sub in child:

--- a/dicttoxml.py
+++ b/dicttoxml.py
@@ -441,4 +441,4 @@ def xmltodict(obj):
     output = {}
     for child in root:
         add_to_output(output, child)
-    return output
+    return {root.tag: output}

--- a/test/unit_tests.py
+++ b/test/unit_tests.py
@@ -23,7 +23,7 @@ class UnitTests(unittest.TestCase):
         }
         xml = dicttoxml.dicttoxml(input)
         output = dicttoxml.xmltodict(xml)
-        self.assertEqual(input, output)
+        self.assertEqual({'root': input}, output)
 
 if __name__== "__main__":
     unittest.main()

--- a/test/unit_tests.py
+++ b/test/unit_tests.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+
+import os, sys
+import unittest
+import dicttoxml
+
+class UnitTests(unittest.TestCase):
+
+    def test_xmltodict(self):
+        input = {
+            'string' : "This is a string with special characters",
+            'empty_string' : '',
+            'int' : 1002,
+            'float' : 12.56,
+            'other_float' : float(80),
+            'boolean' : False,
+            'none_type' : None,
+            'list' : [99, 'sheep', 'dog'],
+            'empty_list' : [],
+            'list_of_dicts' : [{}, {'hi_there': 7, 'owl': 'exterminator'}, {'foo': 56.2, 'ok': True}],
+            'dict_of_lists' : {'list1': [3, 6, 'dog', 'cat', False], 'empty_list': []},
+            'nested_lists' : [[4, 5, 6, 7], [1, 2, 3, 4, [5, 6, 7, 8]]]
+        }
+        print(input)
+        xml = dicttoxml.dicttoxml(input)
+        print(xml)
+        output = dicttoxml.xmltodict(xml)
+        print(output)
+        self.assertEqual(input, output)
+
+if __name__== "__main__":
+    unittest.main()

--- a/test/unit_tests.py
+++ b/test/unit_tests.py
@@ -21,11 +21,8 @@ class UnitTests(unittest.TestCase):
             'dict_of_lists' : {'list1': [3, 6, 'dog', 'cat', False], 'empty_list': []},
             'nested_lists' : [[4, 5, 6, 7], [1, 2, 3, 4, [5, 6, 7, 8]]]
         }
-        print(input)
         xml = dicttoxml.dicttoxml(input)
-        print(xml)
         output = dicttoxml.xmltodict(xml)
-        print(output)
         self.assertEqual(input, output)
 
 if __name__== "__main__":


### PR DESCRIPTION
This PR adds a function called xmltodict that will parse an XML sting created using dicttoxml. The XML must have a type attribute for each tag and only supports standard data types. I've added a description to the readme.

This addresses Issue #71.