### PR TITLE
XML output to be more consistent with standard json to xml interpreters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+
+build/lib/dicttoxml.py

--- a/dicttoxml.py
+++ b/dicttoxml.py
@@ -316,11 +316,7 @@ def convert_dict(obj, ids, parent, attr_type, item_func, cdata):
     return ''.join(output)
 
 def isnested(obj):
-    for i, item in enumerate(obj):
-        if isinstance(item, collections.Iterable):
-            return True
-    
-    return False
+    return any(isinstance(i, list) for i in obj)
 
 def convert_list(items, ids, parent, attr_type, item_func, cdata):
     """Converts a list into an XML string."""
@@ -329,6 +325,9 @@ def convert_list(items, ids, parent, attr_type, item_func, cdata):
     addline = output.append
 
     nested = isnested(items)
+    # default nested to true if parent is a list
+    if parent in default_lst:
+        nested = True
 
     if attr_type or parent == root_name or nested:
         item_name = item_func(parent)


### PR DESCRIPTION
xml output when using this tool for json to xml conversions was not consistent with the output found with some online json/yaml to xml converters:
https://www.convertjson.com/json-to-xml.htm
https://onlinexmltools.com/convert-json-to-xml
http://beautifytools.com/json-to-xml-converter.php

I've modified the code so that output is the same as these online converters. I realize this may not be within the scope or the desired functionality for this repository, but this was the best python tool I found for interpreting json to xml, and may be useful for others in the same fashion as well.

I have not added tests to this repo, but I do have some examples in the wrapper I made for this repository, https://github.com/kobbled/yamljson2xml/tree/master/examples. 