### PR TITLE
handle bool values properly

### DIFF
--- a/dicttoxml.py
+++ b/dicttoxml.py
@@ -172,15 +172,15 @@ def convert(obj, ids, attr_type, item_func, cdata, parent='root'):
     LOG.info('Inside convert(). obj type is: "%s", obj="%s"' % (type(obj).__name__, unicode_me(obj)))
     
     item_name = item_func(parent)
+
+    if type(obj) == bool:
+        return convert_bool(item_name, obj, attr_type, cdata)
     
     if isinstance(obj, numbers.Number) or type(obj) in (str, unicode):
         return convert_kv(item_name, obj, attr_type, cdata)
         
     if hasattr(obj, 'isoformat'):
         return convert_kv(item_name, obj.isoformat(), attr_type, cdata)
-        
-    if type(obj) == bool:
-        return convert_bool(item_name, obj, attr_type, cdata)
         
     if obj is None:
         return convert_none(item_name, '', attr_type, cdata)
@@ -213,14 +213,14 @@ def convert_dict(obj, ids, parent, attr_type, item_func, cdata):
 
         key, attr = make_valid_xml_name(key, attr)
 
-        if isinstance(val, numbers.Number) or type(val) in (str, unicode):
+        if type(val) == bool:
+            addline(convert_bool(key, val, attr_type, attr, cdata))
+
+        elif isinstance(val, numbers.Number) or type(val) in (str, unicode):
             addline(convert_kv(key, val, attr_type, attr, cdata))
 
         elif hasattr(val, 'isoformat'): # datetime
             addline(convert_kv(key, val.isoformat(), attr_type, attr, cdata))
-
-        elif type(val) == bool:
-            addline(convert_bool(key, val, attr_type, attr, cdata))
 
         elif isinstance(val, dict):
             if attr_type:

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -1,0 +1,32 @@
+import unittest
+from collections import OrderedDict
+
+from dicttoxml import dicttoxml
+
+
+class TestDictToXml(unittest.TestCase):
+    def test_primitive_types(self):
+        data = OrderedDict()
+        data['true'] = True
+        data['false'] = False
+        data['int'] = 42
+        data['float'] = 42.0
+        data['None'] = None
+        data['string'] = 'str_value'
+
+        xml = dicttoxml(data, root=False, attr_type=False)
+        self.assertEqual(
+            xml, 
+            (
+                '<true>true</true>'
+                '<false>false</false>'
+                '<int>42</int>'
+                '<float>42.0</float>'
+                '<None></None>'
+                '<string>str_value</string>'
+            )
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Hi there,
I think I found a bug into your library. 

Your library has a problem with handling boolean values. It always handles it like numbers, because:
```bash
Python 2.7.18 (default, Mar  8 2021, 13:02:45) 
[GCC 9.3.0] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import numbers
>>> obj = True
>>> isinstance(obj, numbers.Number)
True
>>> obj = False
>>> isinstance(obj, numbers.Number)
True
>>> obj = 1
>>> isinstance(obj, numbers.Number)
True
```
Solution:
I've change the order of type handlers a little. 
