### PR TITLE
Update dicttoxml.py

### DIFF
--- a/dicttoxml.py
+++ b/dicttoxml.py
@@ -96,7 +96,7 @@ def get_xml_type(val):
         return 'null'
     if isinstance(val, dict):
         return 'dict'
-    if isinstance(val, collections.Iterable):
+    if isinstance(val, collections.abc.Iterable):
         return 'list'
     return type(val).__name__
 
@@ -188,7 +188,7 @@ def convert(obj, ids, attr_type, item_func, cdata, parent='root'):
     if isinstance(obj, dict):
         return convert_dict(obj, ids, parent, attr_type, item_func, cdata)
         
-    if isinstance(obj, collections.Iterable):
+    if isinstance(obj, collections.abc.Iterable):
         return convert_list(obj, ids, parent, attr_type, item_func, cdata)
         
     raise TypeError('Unsupported data type: %s (%s)' % (obj, type(obj).__name__))
@@ -232,7 +232,7 @@ def convert_dict(obj, ids, parent, attr_type, item_func, cdata):
                 )
             )
 
-        elif isinstance(val, collections.Iterable):
+        elif isinstance(val, collections.abc.Iterable):
             if attr_type:
                 attr['type'] = get_xml_type(val)
             addline('<%s%s>%s</%s>' % (
@@ -295,7 +295,7 @@ def convert_list(items, ids, parent, attr_type, item_func, cdata):
                     )
                 )
 
-        elif isinstance(item, collections.Iterable):
+        elif isinstance(item, collections.abc.Iterable):
             if not attr_type:
                 addline('<%s %s>%s</%s>' % (
                     item_name, make_attrstring(attr), 
@@ -397,4 +397,3 @@ def dicttoxml(obj, root=True, custom_root='root', ids=False, attr_type=True,
     else:
         addline(convert(obj, ids, attr_type, item_func, cdata, parent=''))
     return ''.join(output).encode('utf-8')
-


### PR DESCRIPTION
In Python 3.3 the collections.Iterable module was deprecated and replaced by collections.abc.Iterable. It was removed in 3.10.