### PR TITLE
Fix AttributeError: module 'collections' has no attribute 'abc'

### DIFF
--- a/dicttoxml.py
+++ b/dicttoxml.py
@@ -15,10 +15,11 @@ __version__ = '1.7.5'
 version = __version__
 
 from random import randint
-import collections
 try:
+    import collections.abc
     iterable = collections.abc.Iterable
-except AttributeError:
+except ImportError:
+    import collections
     iterable = collections.Iterable
 
 import numbers


### PR DESCRIPTION
See https://github.com/conda-forge/dicttoxml-feedstock/pull/5#issuecomment-1327181435