### PR TITLE
Update setup.py to support python versions 3.6+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
     author_email = 'ryan@quandyfactory.com',
     license = 'LICENCE.txt',
     url = 'https://github.com/quandyfactory/dicttoxml',
+    python_requires=">=3.6",
     py_modules = ['dicttoxml'],
     platforms='Cross-platform',
 )


### PR DESCRIPTION
Since last week I have problem with old project on python 2.7 using dicttoxml without fixed version. It had version 1.7.4 before, now it's 1.7.13 and causes UnicodeDecodeError.